### PR TITLE
It's impossible to put metadata on a cell

### DIFF
--- a/src/tailrecursion/javelin.cljs
+++ b/src/tailrecursion/javelin.cljs
@@ -74,6 +74,10 @@
   cljs.core/IMeta
   (-meta [this] meta)
 
+  cljs.core/IWithMeta
+  (-with-meta [this meta]
+    (Cell. meta state rank prev sources sinks thunk watches update))
+
   cljs.core/IDeref
   (-deref [this] (.-state this))
 


### PR DESCRIPTION
Clojure's `atom` receives optional second argument, taking `:meta` as one of the options - should `cell` maybe replicate this behavior? Another option is implementing `IWithMeta` to support `with-meta` function.
