### PR TITLE
require macros in cljs file to make requires in apps easier

### DIFF
--- a/src/tailrecursion/javelin.cljs
+++ b/src/tailrecursion/javelin.cljs
@@ -7,6 +7,7 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns tailrecursion.javelin
+  (:require-macros [tailrecursion.javelin])
   (:require [tailrecursion.priority-map :refer [priority-map]]))
 
 ;; helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This change will make it possible to do

```
(require '[tailrecursion.javelin :as javelin])
(javelin/cell nil)
```

Instead of the dance with require-macros etc.